### PR TITLE
feat: introduce shared mobile UI styles

### DIFF
--- a/data_entry/harvest.php
+++ b/data_entry/harvest.php
@@ -19,6 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bed_id'], $_POST['har
   <title>収穫入力（マスタDB対応）</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="mobile-ui.css">
 </head>
 <body>
 <div class="container py-4">
@@ -54,7 +55,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bed_id'], $_POST['har
     </div>
 
     <!-- サイクル履歴表示 -->
-    <div id="cycle_history" class="mb-4 p-3 bg-light border rounded" style="display:none;">
+    <div id="cycle_history" class="mb-4 p-3 bg-light border rounded">
       <h6>サイクル履歴</h6>
       <div id="cycle_history_content">選択したベッドの履歴を表示します。</div>
     </div>

--- a/data_entry/mobile-ui.css
+++ b/data_entry/mobile-ui.css
@@ -1,0 +1,50 @@
+/* Common mobile UI styles */
+html, body {
+  font-size: 16px;
+  overflow-x: hidden;
+}
+
+/* spacing between labels and inputs */
+label + .form-control,
+label + .form-select,
+label + .btn-group,
+label + textarea {
+  margin-top: 0.5rem;
+}
+
+/* hide cycle history initially */
+#cycle_history {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  /* ensure touch target size */
+  input,
+  select,
+  textarea,
+  button,
+  .btn {
+    min-height: 44px;
+    font-size: 1rem;
+  }
+
+  /* buttons full width with spacing */
+  .btn {
+    width: 100%;
+    margin-bottom: 0.5rem;
+    padding: 0.75rem 1rem;
+  }
+
+  .btn-group {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  /* larger circular radio/checkbox */
+  input[type="radio"],
+  input[type="checkbox"] {
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 50%;
+  }
+}


### PR DESCRIPTION
## Summary
- extract inline styles from harvest input page into `mobile-ui.css`
- add responsive mobile UI adjustments for better touch targets and vertical form layout
- load shared stylesheet in harvest.php

## Testing
- `php -l data_entry/harvest.php`
- `php test.php`


------
https://chatgpt.com/codex/tasks/task_e_6891f2bb54c48324b5d6a705ccdf3d1a