### PR TITLE
Fix cookie issue by removing closing tag from DB config

### DIFF
--- a/db.php.sample
+++ b/db.php.sample
@@ -6,4 +6,3 @@ if (mysqli_connect_errno() > 0) {
 }
 mysqli_select_db($link, 'database_name');
 mysqli_set_charset($link, 'utf8');
-?>


### PR DESCRIPTION
## Summary
- Remove `?>` from `db.php.sample` to prevent accidental output that breaks `setcookie`

## Testing
- `php -l db.php.sample`
- `php -l data_entry/harvest.php`


------
https://chatgpt.com/codex/tasks/task_e_689200e72c1883248595c713a25f3e96