### PR TITLE
feat: add mobile dashboard and forms

### DIFF
--- a/data_entry/harvest.php
+++ b/data_entry/harvest.php
@@ -12,9 +12,34 @@ if (!$selected_user_id && !empty($_SERVER['HTTP_COOKIE'])) {
 }
 
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bed_id'], $_POST['harvest_date'], $_POST['harvest_kg'], $_POST['loss_type_id'], $_POST['harvest_ratio'], $_POST['user_id'])) {
-    $stmt = mysqli_prepare($link, "INSERT INTO harvests (cycle_id, harvest_date, harvest_kg, loss_type_id, user_id, harvest_ratio, note) VALUES (?, ?, ?, ?, ?, ?, ?)");
-    mysqli_stmt_bind_param($stmt, 'isdiids', $_POST['cycle_id'], $_POST['harvest_date'], $_POST['harvest_kg'], $_POST['loss_type_id'], $_POST['user_id'], $_POST['harvest_ratio'], $_POST['note']);
+if (
+    $_SERVER['REQUEST_METHOD'] === 'POST' &&
+    isset(
+        $_POST['bed_id'],
+        $_POST['harvest_date'],
+        $_POST['harvest_kg'],
+        $_POST['loss_type_id'],
+        $_POST['harvest_ratio'],
+        $_POST['user_id'],
+        $_POST['size_eval']
+    )
+) {
+    $stmt = mysqli_prepare(
+        $link,
+        "INSERT INTO harvests (cycle_id, harvest_date, harvest_kg, loss_type_id, user_id, harvest_ratio, size_eval, note) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+    );
+    mysqli_stmt_bind_param(
+        $stmt,
+        'isdiidss',
+        $_POST['cycle_id'],
+        $_POST['harvest_date'],
+        $_POST['harvest_kg'],
+        $_POST['loss_type_id'],
+        $_POST['user_id'],
+        $_POST['harvest_ratio'],
+        $_POST['size_eval'],
+        $_POST['note']
+    );
     mysqli_stmt_execute($stmt);
     mysqli_stmt_close($stmt);
     setcookie('gf_fc_useit_id', $_POST['user_id'], time() + (60 * 60 * 24 * 14), '/');
@@ -31,7 +56,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bed_id'], $_POST['har
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="../css/mobile-ui.css">
 </head>
-<body>
+<body class="pb-5">
 <div class="container py-4">
   <h4 class="mb-4 text-primary">🌱 収穫入力</h4>
   <form method="POST">
@@ -101,6 +126,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bed_id'], $_POST['har
       <input id="harvest_kg" type="number" step="0.1" class="form-control form-control-lg" name="harvest_kg" required>
     </div>
 
+    <!-- 状態 -->
+    <div class="mb-4">
+      <label class="form-label fs-5">状態</label><br>
+      <div class="btn-group w-100" role="group">
+        <input type="radio" class="btn-check" name="size_eval" id="s1" value="big" required>
+        <label class="btn btn-outline-secondary" for="s1">大きめ</label>
+        <input type="radio" class="btn-check" name="size_eval" id="s2" value="normal">
+        <label class="btn btn-outline-secondary" for="s2">適当</label>
+        <input type="radio" class="btn-check" name="size_eval" id="s3" value="small">
+        <label class="btn btn-outline-secondary" for="s3">小さめ</label>
+      </div>
+    </div>
+
     <!-- 廃棄・ゴミ区分 -->
     <div class="mb-4">
       <label for="loss_type_id" class="form-label fs-5">廃棄・ゴミ区分</label>
@@ -126,6 +164,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bed_id'], $_POST['har
     </div>
   </form>
 </div>
+
+<nav class="navbar fixed-bottom bg-light border-top">
+  <div class="container-fluid">
+    <div class="d-flex justify-content-around w-100">
+      <a href="../index.php" class="text-center nav-link"><div>🏠</div><small>ホーム</small></a>
+      <a href="../monitor.php" class="text-center nav-link"><div>🌱</div><small>栽培状況</small></a>
+      <a href="../inventory.php" class="text-center nav-link"><div>📊</div><small>在庫</small></a>
+      <a href="../plan.php" class="text-center nav-link"><div>📅</div><small>計画</small></a>
+      <a href="../settings.php" class="text-center nav-link"><div>⚙️</div><small>設定</small></a>
+    </div>
+  </div>
+</nav>
 
 <script>
 function saveUserCookie() {

--- a/data_entry/planting.php
+++ b/data_entry/planting.php
@@ -1,0 +1,67 @@
+<?php
+require_once '../db.php';
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>定植入力</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="../css/mobile-ui.css">
+</head>
+<body class="pb-5">
+<div class="container py-4">
+  <h4 class="mb-4 text-primary">🌱 定植入力</h4>
+  <form>
+    <div class="mb-4">
+      <label for="plant_date" class="form-label fs-5">定植日</label>
+      <input type="date" id="plant_date" class="form-control form-control-lg" required>
+    </div>
+    <div class="mb-4">
+      <label for="bed" class="form-label fs-5">ベッド名</label>
+      <select id="bed" class="form-select form-select-lg" required>
+        <option value="">選択してください</option>
+        <?php
+        $res = mysqli_query($link, "SELECT id, name FROM beds WHERE active=1 ORDER BY name");
+        while ($b = mysqli_fetch_assoc($res)) {
+            echo "<option value='{$b['id']}'>{$b['name']}</option>";
+        }
+        ?>
+      </select>
+    </div>
+    <div class="mb-4">
+      <label for="sow_date" class="form-label fs-5">播種日</label>
+      <input type="date" id="sow_date" class="form-control form-control-lg" required>
+      <div class="form-text">育苗日数: <span id="nursery_days">0</span>日</div>
+    </div>
+    <div class="d-grid">
+      <button type="submit" class="btn btn-primary btn-lg">登録</button>
+    </div>
+  </form>
+</div>
+<nav class="navbar fixed-bottom bg-light border-top">
+  <div class="container-fluid">
+    <div class="d-flex justify-content-around w-100">
+      <a href="../index.php" class="text-center nav-link"><div>🏠</div><small>ホーム</small></a>
+      <a href="../monitor.php" class="text-center nav-link"><div>🌱</div><small>栽培状況</small></a>
+      <a href="../inventory.php" class="text-center nav-link"><div>📊</div><small>在庫</small></a>
+      <a href="../plan.php" class="text-center nav-link"><div>📅</div><small>計画</small></a>
+      <a href="../settings.php" class="text-center nav-link"><div>⚙️</div><small>設定</small></a>
+    </div>
+  </div>
+</nav>
+<script>
+function calcDays(){
+  const plant = new Date(document.getElementById('plant_date').value);
+  const sow = new Date(document.getElementById('sow_date').value);
+  if(!isNaN(plant) && !isNaN(sow)){
+    const diff = (plant - sow)/(1000*60*60*24);
+    document.getElementById('nursery_days').innerText = diff;
+  }
+}
+document.getElementById('plant_date').addEventListener('change', calcDays);
+document.getElementById('sow_date').addEventListener('change', calcDays);
+</script>
+</body>
+</html>

--- a/data_entry/treatment.php
+++ b/data_entry/treatment.php
@@ -1,0 +1,66 @@
+<?php
+require_once '../db.php';
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>防除・追肥入力</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="../css/mobile-ui.css">
+</head>
+<body class="pb-5">
+<div class="container py-4">
+  <h4 class="mb-4 text-primary">🛠 防除・追肥入力</h4>
+  <form>
+    <div class="mb-4">
+      <label for="treat_date" class="form-label fs-5">実施日</label>
+      <input type="date" id="treat_date" class="form-control form-control-lg" required>
+    </div>
+    <div class="mb-4">
+      <label for="bed" class="form-label fs-5">ベッド名</label>
+      <select id="bed" class="form-select form-select-lg" required>
+        <option value="">選択してください</option>
+        <?php
+        $res = mysqli_query($link, "SELECT id, name FROM beds WHERE active=1 ORDER BY name");
+        while ($b = mysqli_fetch_assoc($res)) {
+            echo "<option value='{$b['id']}'>{$b['name']}</option>";
+        }
+        ?>
+      </select>
+    </div>
+    <div class="mb-4">
+      <label for="pesticide" class="form-label fs-5">使用農薬名</label>
+      <input type="text" id="pesticide" class="form-control form-control-lg">
+    </div>
+    <div class="mb-4">
+      <label for="dilution" class="form-label fs-5">希釈倍数・使用量</label>
+      <input type="text" id="dilution" class="form-control form-control-lg">
+    </div>
+    <div class="mb-4">
+      <label for="method" class="form-label fs-5">手段</label>
+      <input type="text" id="method" class="form-control form-control-lg">
+    </div>
+    <div class="mb-4">
+      <label for="status" class="form-label fs-5">作物の状況</label>
+      <textarea id="status" class="form-control" rows="3"></textarea>
+    </div>
+    <div class="d-grid">
+      <button type="submit" class="btn btn-primary btn-lg">登録</button>
+    </div>
+  </form>
+</div>
+<nav class="navbar fixed-bottom bg-light border-top">
+  <div class="container-fluid">
+    <div class="d-flex justify-content-around w-100">
+      <a href="../index.php" class="text-center nav-link"><div>🏠</div><small>ホーム</small></a>
+      <a href="../monitor.php" class="text-center nav-link"><div>🌱</div><small>栽培状況</small></a>
+      <a href="../inventory.php" class="text-center nav-link"><div>📊</div><small>在庫</small></a>
+      <a href="../plan.php" class="text-center nav-link"><div>📅</div><small>計画</small></a>
+      <a href="../settings.php" class="text-center nav-link"><div>⚙️</div><small>設定</small></a>
+    </div>
+  </div>
+</nav>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,87 @@
+<?php
+// Home Dashboard
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ホームダッシュボード</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="css/mobile-ui.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="pb-5">
+<div class="container my-4">
+  <ul class="nav nav-tabs mb-3">
+    <li class="nav-item"><a class="nav-link active" href="#">週別</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">月別</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">年別</a></li>
+  </ul>
+  <h5 class="mb-3">2025-08-04週</h5>
+  <div class="row text-center mb-4">
+    <div class="col-4 mb-3">
+      <div class="border rounded p-2">
+        <small>収穫予定 vs 実績</small>
+        <div class="fs-5">120kg / 110kg</div>
+        <div class="text-success">+10kg</div>
+      </div>
+    </div>
+    <div class="col-4 mb-3">
+      <div class="border rounded p-2">
+        <small>在庫差</small>
+        <div class="fs-5">-8kg</div>
+      </div>
+    </div>
+    <div class="col-4 mb-3">
+      <div class="border rounded p-2">
+        <small>廃棄リスク数</small>
+        <div class="fs-5">2</div>
+      </div>
+    </div>
+  </div>
+  <canvas id="harvestChart" class="mb-4"></canvas>
+  <canvas id="inventoryChart" class="mb-4"></canvas>
+  <div class="card">
+    <div class="card-header">アラート</div>
+    <ul class="list-group list-group-flush">
+      <li class="list-group-item">在庫不足：9/1週</li>
+      <li class="list-group-item">廃棄リスク：ベッドA</li>
+      <li class="list-group-item">定植計画未達：2ベッド</li>
+    </ul>
+  </div>
+</div>
+<nav class="navbar fixed-bottom bg-light border-top">
+  <div class="container-fluid">
+    <div class="d-flex justify-content-around w-100">
+      <a href="index.php" class="text-center nav-link active"><div>🏠</div><small>ホーム</small></a>
+      <a href="monitor.php" class="text-center nav-link"><div>🌱</div><small>栽培状況</small></a>
+      <a href="inventory.php" class="text-center nav-link"><div>📊</div><small>在庫</small></a>
+      <a href="plan.php" class="text-center nav-link"><div>📅</div><small>計画</small></a>
+      <a href="settings.php" class="text-center nav-link"><div>⚙️</div><small>設定</small></a>
+    </div>
+  </div>
+</nav>
+<script>
+const ctx1 = document.getElementById('harvestChart');
+new Chart(ctx1, {
+  type: 'bar',
+  data: {
+    labels: ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'],
+    datasets: [
+      {label: '予定', data: [20,20,20,20,20,10,10], backgroundColor:'rgba(54,162,235,0.5)'},
+      {label: '実績', data: [18,22,19,17,25,8,12], backgroundColor:'rgba(75,192,192,0.5)'}
+    ]
+  }
+});
+const ctx2 = document.getElementById('inventoryChart');
+new Chart(ctx2, {
+  type: 'line',
+  data: {
+    labels: ['先週','今週','来週'],
+    datasets: [{label:'在庫差', data:[-5,10,-8], borderColor:'rgb(255,99,132)', tension:0.3}]
+  }
+});
+</script>
+</body>
+</html>

--- a/inventory.php
+++ b/inventory.php
@@ -1,0 +1,58 @@
+<?php
+// Forecast & Inventory Visualization
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>予測＆在庫可視化</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="css/mobile-ui.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="pb-5">
+<div class="container my-4">
+  <ul class="nav nav-tabs mb-3">
+    <li class="nav-item"><a class="nav-link active" href="#">週別</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">月別</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">年別</a></li>
+  </ul>
+  <div class="mb-3">
+    <h6>差分サマリー</h6>
+    <div class="border rounded p-3">
+      在庫差合計：<span class="text-danger">-20kg</span><br>
+      赤字週数：3
+    </div>
+  </div>
+  <canvas id="diffChart" class="mb-4"></canvas>
+  <canvas id="accChart" class="mb-4"></canvas>
+  <h6>在庫不足リスト</h6>
+  <ul class="list-group">
+    <li class="list-group-item">ベッドA 不足5kg → 9/1収穫で補填</li>
+    <li class="list-group-item">ベッドB 不足3kg → 9/8収穫で補填</li>
+  </ul>
+</div>
+<nav class="navbar fixed-bottom bg-light border-top">
+  <div class="container-fluid">
+    <div class="d-flex justify-content-around w-100">
+      <a href="index.php" class="text-center nav-link"><div>🏠</div><small>ホーム</small></a>
+      <a href="monitor.php" class="text-center nav-link"><div>🌱</div><small>栽培状況</small></a>
+      <a href="inventory.php" class="text-center nav-link active"><div>📊</div><small>在庫</small></a>
+      <a href="plan.php" class="text-center nav-link"><div>📅</div><small>計画</small></a>
+      <a href="settings.php" class="text-center nav-link"><div>⚙️</div><small>設定</small></a>
+    </div>
+  </div>
+</nav>
+<script>
+new Chart(document.getElementById('diffChart'), {
+  type:'bar',
+  data:{labels:['1週','2週','3週','4週'], datasets:[{label:'在庫差', data:[-5,-8,3,-10], backgroundColor:'rgba(255,99,132,0.5)'}]}
+});
+new Chart(document.getElementById('accChart'), {
+  type:'line',
+  data:{labels:['1週','2週','3週','4週'], datasets:[{label:'累積在庫差', data:[-5,-13,-10,-20], borderColor:'rgb(54,162,235)'}]}
+});
+</script>
+</body>
+</html>

--- a/monitor.php
+++ b/monitor.php
@@ -1,0 +1,96 @@
+<?php
+// Cultivation Status Monitor
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>栽培状況モニター</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="css/mobile-ui.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="pb-5">
+<div class="container my-4">
+  <ul class="nav nav-tabs mb-3">
+    <li class="nav-item"><a class="nav-link active" href="#">週別</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">月別</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">年別</a></li>
+  </ul>
+  <div class="row mb-3">
+    <div class="col-6">
+      <label class="form-label">グループ</label>
+      <select class="form-select">
+        <option>通常</option>
+        <option>別宅</option>
+      </select>
+    </div>
+    <div class="col-6">
+      <label class="form-label">状態</label>
+      <select class="form-select">
+        <option>全体</option>
+        <option>定植中</option>
+        <option>生育中</option>
+        <option>収穫中</option>
+      </select>
+    </div>
+  </div>
+  <div class="mb-4">
+    <h6>栽培カレンダー</h6>
+    <table class="table table-bordered text-center small">
+      <thead><tr><th>ベッド\日</th><th>Mon</th><th>Tue</th><th>Wed</th><th>Thu</th><th>Fri</th><th>Sat</th><th>Sun</th></tr></thead>
+      <tbody>
+        <tr><th>A1</th><td class="bg-info">定植</td><td class="bg-success">生育</td><td class="bg-success">生育</td><td class="bg-warning">収穫</td><td></td><td></td><td></td></tr>
+        <tr><th>B2</th><td class="bg-info">定植</td><td class="bg-success">生育</td><td class="bg-success">生育</td><td class="bg-success">生育</td><td class="bg-warning">収穫</td><td></td><td></td></tr>
+      </tbody>
+    </table>
+  </div>
+  <canvas id="harvestTrend" class="mb-4"></canvas>
+  <canvas id="dayTrend" class="mb-4"></canvas>
+  <div class="card mb-3">
+    <div class="card-header">詳細</div>
+    <div class="card-body">
+      <p>温度推移や予測収量を表示します。</p>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card-header">防除・追肥</div>
+    <ul class="list-group list-group-flush">
+      <li class="list-group-item">8/1 防除：薬剤A</li>
+      <li class="list-group-item">8/3 追肥：液肥B</li>
+    </ul>
+  </div>
+</div>
+<nav class="navbar fixed-bottom bg-light border-top">
+  <div class="container-fluid">
+    <div class="d-flex justify-content-around w-100">
+      <a href="index.php" class="text-center nav-link"><div>🏠</div><small>ホーム</small></a>
+      <a href="monitor.php" class="text-center nav-link active"><div>🌱</div><small>栽培状況</small></a>
+      <a href="inventory.php" class="text-center nav-link"><div>📊</div><small>在庫</small></a>
+      <a href="plan.php" class="text-center nav-link"><div>📅</div><small>計画</small></a>
+      <a href="settings.php" class="text-center nav-link"><div>⚙️</div><small>設定</small></a>
+    </div>
+  </div>
+</nav>
+<script>
+new Chart(document.getElementById('harvestTrend'), {
+  type: 'bar',
+  data: {
+    labels:['1週','2週','3週','4週'],
+    datasets:[
+      {label:'実績', data:[30,40,35,50], backgroundColor:'rgba(75,192,192,0.5)'},
+      {label:'予測', data:[32,42,38,48], backgroundColor:'rgba(54,162,235,0.5)'}
+    ]
+  }
+});
+new Chart(document.getElementById('dayTrend'), {
+  type: 'line',
+  data: {
+    labels:['1週','2週','3週','4週'],
+    datasets:[{label:'平均生育日数', data:[30,28,27,29], borderColor:'orange'}]
+  }
+});
+</script>
+</body>
+</html>

--- a/plan.php
+++ b/plan.php
@@ -1,0 +1,73 @@
+<?php
+// Cultivation Plan Visualization
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>栽培計画可視化</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="css/mobile-ui.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="pb-5">
+<div class="container my-4">
+  <ul class="nav nav-tabs mb-3">
+    <li class="nav-item"><a class="nav-link active" href="#">週別</a></li>
+    <li class="nav-item"><a class="nav-link" href="#">月別</a></li>
+  </ul>
+  <div class="row text-center mb-4">
+    <div class="col-4">
+      <div class="border rounded p-2">
+        <small>必要定植数</small>
+        <div class="fs-5">12</div>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="border rounded p-2">
+        <small>実績定植数</small>
+        <div class="fs-5">8</div>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="border rounded p-2">
+        <small>達成率</small>
+        <div class="fs-5">67%</div>
+      </div>
+    </div>
+  </div>
+  <canvas id="plantChart" class="mb-4"></canvas>
+  <canvas id="supplyChart" class="mb-4"></canvas>
+  <div class="mb-3">
+    <label for="scenario" class="form-label">シナリオ：定植数</label>
+    <input type="range" class="form-range" min="0" max="20" value="8" id="scenario" oninput="updateScenario(this.value)">
+    <div>選択値: <span id="scenarioVal">8</span> ベッド</div>
+  </div>
+</div>
+<nav class="navbar fixed-bottom bg-light border-top">
+  <div class="container-fluid">
+    <div class="d-flex justify-content-around w-100">
+      <a href="index.php" class="text-center nav-link"><div>🏠</div><small>ホーム</small></a>
+      <a href="monitor.php" class="text-center nav-link"><div>🌱</div><small>栽培状況</small></a>
+      <a href="inventory.php" class="text-center nav-link"><div>📊</div><small>在庫</small></a>
+      <a href="plan.php" class="text-center nav-link active"><div>📅</div><small>計画</small></a>
+      <a href="settings.php" class="text-center nav-link"><div>⚙️</div><small>設定</small></a>
+    </div>
+  </div>
+</nav>
+<script>
+new Chart(document.getElementById('plantChart'), {
+  type:'bar',
+  data:{labels:['1週','2週','3週','4週'], datasets:[{label:'必要', data:[3,4,3,2], backgroundColor:'rgba(54,162,235,0.5)'},{label:'実績', data:[2,3,2,1], backgroundColor:'rgba(75,192,192,0.5)'}]}
+});
+new Chart(document.getElementById('supplyChart'), {
+  type:'line',
+  data:{labels:['1週','2週','3週','4週'], datasets:[{label:'予測収穫量充足率', data:[80,70,90,85], borderColor:'green'}]}
+});
+function updateScenario(val){
+  document.getElementById('scenarioVal').innerText = val;
+}
+</script>
+</body>
+</html>

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,40 @@
+<?php
+// Settings and Management
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>設定・運用管理</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="css/mobile-ui.css">
+</head>
+<body class="pb-5">
+<div class="container my-4">
+  <h5 class="mb-3">設定・運用管理</h5>
+  <div class="list-group">
+    <a href="#" class="list-group-item list-group-item-action">ベッド情報管理</a>
+    <a href="#" class="list-group-item list-group-item-action">従業員情報管理</a>
+    <a href="#" class="list-group-item list-group-item-action">廃棄区分管理</a>
+    <a href="#" class="list-group-item list-group-item-action">通知設定</a>
+    <a href="#" class="list-group-item list-group-item-action">モデルアップロード</a>
+    <a href="#" class="list-group-item list-group-item-action">温度データ取込</a>
+    <a href="data_entry/planting.php" class="list-group-item list-group-item-action">定植入力フォーム</a>
+    <a href="data_entry/harvest.php" class="list-group-item list-group-item-action">収穫入力フォーム</a>
+    <a href="data_entry/treatment.php" class="list-group-item list-group-item-action">防除・追肥入力フォーム</a>
+  </div>
+</div>
+<nav class="navbar fixed-bottom bg-light border-top">
+  <div class="container-fluid">
+    <div class="d-flex justify-content-around w-100">
+      <a href="index.php" class="text-center nav-link"><div>🏠</div><small>ホーム</small></a>
+      <a href="monitor.php" class="text-center nav-link"><div>🌱</div><small>栽培状況</small></a>
+      <a href="inventory.php" class="text-center nav-link"><div>📊</div><small>在庫</small></a>
+      <a href="plan.php" class="text-center nav-link"><div>📅</div><small>計画</small></a>
+      <a href="settings.php" class="text-center nav-link active"><div>⚙️</div><small>設定</small></a>
+    </div>
+  </div>
+</nav>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build mobile-friendly dashboard with KPI cards, charts, alerts, and tab navigation
- add cultivation monitor, inventory view, and planning screen with scenario slider
- include settings hub and forms for planting, harvest (with size eval), and treatments

## Testing
- `php -l index.php monitor.php inventory.php plan.php settings.php data_entry/planting.php data_entry/treatment.php data_entry/harvest.php`


------
https://chatgpt.com/codex/tasks/task_e_68929563456883248efdf6cbbca032da