### PR TITLE
feat: enhance cultivation monitor

### DIFF
--- a/monitor.php
+++ b/monitor.php
@@ -1,5 +1,96 @@
 <?php
-// Cultivation Status Monitor
+require_once 'db.php';
+
+$group = $_GET['group'] ?? '';
+$statusFilter = $_GET['status'] ?? '';
+$today = date('Y-m-d');
+
+$beds = [];
+$bedSql = "SELECT id, name, group_type FROM beds";
+if ($group && $group !== '') {
+    $grp = mysqli_real_escape_string($link, $group);
+    $bedSql .= " WHERE group_type='{$grp}'";
+}
+$bedSql .= ' ORDER BY name';
+$bedRes = mysqli_query($link, $bedSql);
+if ($bedRes) {
+    while ($b = mysqli_fetch_assoc($bedRes)) {
+        $cycleRes = mysqli_query($link, "SELECT * FROM cycles WHERE bed_id={$b['id']} ORDER BY id DESC LIMIT 1");
+        $cycle = $cycleRes ? mysqli_fetch_assoc($cycleRes) : null;
+        $bedStatus = 'empty';
+        if ($cycle) {
+            if (!empty($cycle['harvest_start']) && !empty($cycle['harvest_end']) && $today >= $cycle['harvest_start'] && $today <= $cycle['harvest_end']) {
+                $bedStatus = 'harvesting';
+            } elseif (!empty($cycle['plant_date']) && $today >= $cycle['plant_date'] && ($cycle['harvest_start'] === null || $today < $cycle['harvest_start'])) {
+                $bedStatus = 'growing';
+            }
+        }
+        if ($statusFilter && $statusFilter !== $bedStatus) {
+            continue;
+        }
+        $b['cycle'] = $cycle;
+        $beds[] = $b;
+    }
+}
+
+function week_status($cycle, $weekStart) {
+    $weekEnd = strtotime('+6 day', $weekStart);
+    if (!$cycle) return ['', ''];
+    $plant = $cycle['plant_date'] ? strtotime($cycle['plant_date']) : null;
+    $harvestStart = $cycle['harvest_start'] ? strtotime($cycle['harvest_start']) : null;
+    $harvestEnd = $cycle['harvest_end'] ? strtotime($cycle['harvest_end']) : null;
+
+    if ($plant && $plant >= $weekStart && $plant <= $weekEnd) {
+        return ['bg-info text-white', '定植'];
+    }
+    if ($harvestStart && $harvestEnd && $harvestStart <= $weekEnd && $harvestEnd >= $weekStart) {
+        return ['bg-warning', '収穫'];
+    }
+    if ($plant && $weekStart >= $plant && (!$harvestStart || $weekEnd < $harvestStart)) {
+        return ['bg-success text-white', '栽培'];
+    }
+    return ['', ''];
+}
+
+$weekStart = strtotime('monday this week');
+$weekLabels = [];
+for ($i = 0; $i < 7; $i++) {
+    $weekLabels[] = date('n/j', strtotime("+$i week", $weekStart));
+}
+
+$harvestLabels = [];
+$harvestActual = [];
+$res = mysqli_query($link, "SELECT DATE_FORMAT(harvest_date,'%Y-%u') AS wk, SUM(harvest_kg) AS total FROM harvests GROUP BY wk ORDER BY wk DESC LIMIT 7");
+if ($res) {
+    while ($row = mysqli_fetch_assoc($res)) {
+        $harvestLabels[] = $row['wk'];
+        $harvestActual[] = (float)$row['total'];
+    }
+}
+$harvestLabels = array_reverse($harvestLabels);
+$harvestActual = array_reverse($harvestActual);
+$forecastData = array_map(fn($v) => round($v * 1.1, 1), $harvestActual);
+if (!$harvestLabels) {
+    $harvestLabels = ['1週', '2週', '3週', '4週'];
+    $harvestActual = [0, 0, 0, 0];
+    $forecastData = [0, 0, 0, 0];
+}
+
+$dayLabels = [];
+$dayData = [];
+$dRes = mysqli_query($link, "SELECT DATE_FORMAT(harvest_start,'%Y-%u') AS wk, AVG(DATEDIFF(harvest_start, plant_date)) AS avg_days FROM cycles WHERE harvest_start IS NOT NULL GROUP BY wk ORDER BY wk DESC LIMIT 7");
+if ($dRes) {
+    while ($row = mysqli_fetch_assoc($dRes)) {
+        $dayLabels[] = $row['wk'];
+        $dayData[] = (float)$row['avg_days'];
+    }
+}
+$dayLabels = array_reverse($dayLabels);
+$dayData = array_reverse($dayData);
+if (!$dayLabels) {
+    $dayLabels = ['1週', '2週', '3週', '4週'];
+    $dayData = [30, 28, 27, 29];
+}
 ?>
 <!DOCTYPE html>
 <html lang="ja">
@@ -13,38 +104,55 @@
 </head>
 <body class="pb-5">
 <div class="container my-4">
+  <h4 class="mb-3 text-primary">🌱 栽培状況モニター</h4>
+  <form method="get" class="row mb-3">
+    <div class="col-6">
+      <label class="form-label">ベッド区分</label>
+      <select name="group" class="form-select" onchange="this.form.submit()">
+        <option value=""<?= $group === '' ? ' selected' : '' ?>>全体</option>
+        <option value="通常"<?= $group === '通常' ? ' selected' : '' ?>>通常</option>
+        <option value="別宅"<?= $group === '別宅' ? ' selected' : '' ?>>別宅</option>
+      </select>
+    </div>
+    <div class="col-6">
+      <label class="form-label">状態</label>
+      <select name="status" class="form-select" onchange="this.form.submit()">
+        <option value=""<?= $statusFilter === '' ? ' selected' : '' ?>>全体</option>
+        <option value="growing"<?= $statusFilter === 'growing' ? ' selected' : '' ?>>栽培中</option>
+        <option value="harvesting"<?= $statusFilter === 'harvesting' ? ' selected' : '' ?>>収穫中</option>
+        <option value="empty"<?= $statusFilter === 'empty' ? ' selected' : '' ?>>空き</option>
+      </select>
+    </div>
+  </form>
   <ul class="nav nav-tabs mb-3">
     <li class="nav-item"><a class="nav-link active" href="#">週別</a></li>
     <li class="nav-item"><a class="nav-link" href="#">月別</a></li>
     <li class="nav-item"><a class="nav-link" href="#">年別</a></li>
   </ul>
-  <div class="row mb-3">
-    <div class="col-6">
-      <label class="form-label">グループ</label>
-      <select class="form-select">
-        <option>通常</option>
-        <option>別宅</option>
-      </select>
-    </div>
-    <div class="col-6">
-      <label class="form-label">状態</label>
-      <select class="form-select">
-        <option>全体</option>
-        <option>定植中</option>
-        <option>生育中</option>
-        <option>収穫中</option>
-      </select>
-    </div>
-  </div>
   <div class="mb-4">
     <h6>栽培カレンダー</h6>
-    <table class="table table-bordered text-center small">
-      <thead><tr><th>ベッド\日</th><th>Mon</th><th>Tue</th><th>Wed</th><th>Thu</th><th>Fri</th><th>Sat</th><th>Sun</th></tr></thead>
-      <tbody>
-        <tr><th>A1</th><td class="bg-info">定植</td><td class="bg-success">生育</td><td class="bg-success">生育</td><td class="bg-warning">収穫</td><td></td><td></td><td></td></tr>
-        <tr><th>B2</th><td class="bg-info">定植</td><td class="bg-success">生育</td><td class="bg-success">生育</td><td class="bg-success">生育</td><td class="bg-warning">収穫</td><td></td><td></td></tr>
-      </tbody>
-    </table>
+    <div class="table-responsive" style="max-height:400px;">
+      <table class="table table-bordered text-center small align-middle">
+        <thead class="table-light">
+          <tr>
+            <th class="text-nowrap">ベッド\\週</th>
+            <?php foreach ($weekLabels as $wl): ?>
+              <th><?= htmlspecialchars($wl, ENT_QUOTES, 'UTF-8') ?></th>
+            <?php endforeach; ?>
+          </tr>
+        </thead>
+        <tbody>
+          <?php foreach ($beds as $bed): ?>
+            <tr>
+              <th class="text-nowrap"><?= htmlspecialchars($bed['name'], ENT_QUOTES, 'UTF-8') ?></th>
+              <?php for ($i = 0; $i < 7; $i++): $ws = strtotime("+$i week", $weekStart); [$cls, $label] = week_status($bed['cycle'], $ws); ?>
+                <td class="<?= $cls ?>"><?= $label ?></td>
+              <?php endfor; ?>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
   </div>
   <canvas id="harvestTrend" class="mb-4"></canvas>
   <canvas id="dayTrend" class="mb-4"></canvas>
@@ -74,21 +182,26 @@
   </div>
 </nav>
 <script>
+const harvestLabels = <?= json_encode($harvestLabels, JSON_UNESCAPED_UNICODE) ?>;
+const actualData = <?= json_encode($harvestActual, JSON_NUMERIC_CHECK) ?>;
+const forecastData = <?= json_encode($forecastData, JSON_NUMERIC_CHECK) ?>;
 new Chart(document.getElementById('harvestTrend'), {
   type: 'bar',
   data: {
-    labels:['1週','2週','3週','4週'],
-    datasets:[
-      {label:'実績', data:[30,40,35,50], backgroundColor:'rgba(75,192,192,0.5)'},
-      {label:'予測', data:[32,42,38,48], backgroundColor:'rgba(54,162,235,0.5)'}
+    labels: harvestLabels,
+    datasets: [
+      {label: '実績', data: actualData, backgroundColor: 'rgba(75,192,192,0.5)'},
+      {label: '予測', data: forecastData, backgroundColor: 'rgba(54,162,235,0.5)'}
     ]
   }
 });
+const dayLabels = <?= json_encode($dayLabels, JSON_UNESCAPED_UNICODE) ?>;
+const dayData = <?= json_encode($dayData, JSON_NUMERIC_CHECK) ?>;
 new Chart(document.getElementById('dayTrend'), {
   type: 'line',
   data: {
-    labels:['1週','2週','3週','4週'],
-    datasets:[{label:'平均生育日数', data:[30,28,27,29], borderColor:'orange'}]
+    labels: dayLabels,
+    datasets: [{label: '平均生育日数', data: dayData, borderColor: 'orange'}]
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- add page heading and filters for bed group and status
- show 7-week cultivation calendar with database-driven data
- integrate actual harvest and growth metrics with placeholder forecasts

## Testing
- `php -l monitor.php`


------
https://chatgpt.com/codex/tasks/task_e_6892b135e0548324b27a3c9ea4c7fe5a