### PR TITLE
Add cycle prediction API and extended cycle metrics

### DIFF
--- a/api/predict.php
+++ b/api/predict.php
@@ -1,0 +1,28 @@
+<?php
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || !isset($input['cycle_id'])) {
+    echo json_encode(['status' => 'error', 'message' => 'cycle_id required']);
+    exit;
+}
+
+$cycleId = (int)$input['cycle_id'];
+$cmd = 'python3 ' . escapeshellarg(__DIR__ . '/predict_model.py') . ' --cycle_id ' . escapeshellarg($cycleId);
+
+if (!empty($input['apply_partial'])) {
+    if (!isset($input['partial_yield']) || !isset($input['partial_ratio'])) {
+        echo json_encode(['status' => 'error', 'message' => 'partial_yield and partial_ratio required when apply_partial=true']);
+        exit;
+    }
+    $cmd .= ' --apply_partial --partial_yield ' . escapeshellarg($input['partial_yield']) . ' --partial_ratio ' . escapeshellarg($input['partial_ratio']);
+}
+
+exec($cmd, $output, $ret);
+$response = json_decode(implode("\n", $output), true);
+if (!$response) {
+    echo json_encode(['status' => 'error', 'message' => 'Prediction failed']);
+    exit;
+}
+
+echo json_encode($response);

--- a/api/predict_model.py
+++ b/api/predict_model.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+from datetime import timedelta
+
+import pymysql
+import pandas as pd
+import pickle
+
+DB_CONFIG = {
+    'host': 'localhost',
+    'user': 'username',
+    'password': 'password',
+    'db': 'database_name',
+    'charset': 'utf8',
+    'cursorclass': pymysql.cursors.DictCursor,
+}
+
+BASE_GROWTH_DAYS = {1: 70, 2: 100, 3: 85}
+
+
+def determine_season_flag(plant_date):
+    month = plant_date.month
+    if 6 <= month <= 9:
+        return 1
+    elif month in (12, 1, 2):
+        return 2
+    else:
+        return 3
+
+
+def compute_and_update_features(cycle_id):
+    conn = pymysql.connect(**DB_CONFIG)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """SELECT c.*, b.group_type FROM cycles c JOIN beds b ON c.bed_id=b.id WHERE c.id=%s""",
+                (cycle_id,),
+            )
+            cycle = cur.fetchone()
+            if not cycle:
+                return None, "Cycle not found"
+            plant_date = cycle["plant_date"]
+            harvest_start = cycle["harvest_start"]
+            group_type = cycle["group_type"]
+            season_flag = determine_season_flag(plant_date)
+            base_growth_days = BASE_GROWTH_DAYS.get(season_flag)
+            expected_harvest = (
+                plant_date + timedelta(days=base_growth_days)
+                if plant_date and base_growth_days
+                else None
+            )
+            sales_adjust_days = (
+                (harvest_start - expected_harvest).days
+                if harvest_start and expected_harvest
+                else None
+            )
+
+            # Similar bed averages
+            start_range = plant_date - timedelta(days=7)
+            end_range = plant_date + timedelta(days=7)
+            cur.execute(
+                """
+                SELECT AVG(h.total_yield) AS avg_yield,
+                       AVG(DATEDIFF(c.harvest_start, c.plant_date)) AS avg_days
+                FROM cycles c
+                JOIN beds b ON c.bed_id = b.id
+                LEFT JOIN (
+                    SELECT cycle_id, SUM(harvest_kg) AS total_yield
+                    FROM harvests
+                    GROUP BY cycle_id
+                ) h ON c.id = h.cycle_id
+                WHERE b.group_type=%s AND c.id<>%s AND c.plant_date BETWEEN %s AND %s
+                """,
+                (group_type, cycle_id, start_range, end_range),
+            )
+            sim = cur.fetchone()
+            similar_yield = sim["avg_yield"]
+            similar_days = sim["avg_days"]
+
+            # Previous year
+            prev_start = plant_date - timedelta(days=365 + 5)
+            prev_end = plant_date - timedelta(days=365 - 5)
+            cur.execute(
+                """
+                SELECT AVG(h.total_yield) AS avg_yield,
+                       AVG(DATEDIFF(c.harvest_start, c.plant_date)) AS avg_days
+                FROM cycles c
+                JOIN beds b ON c.bed_id = b.id
+                LEFT JOIN (
+                    SELECT cycle_id, SUM(harvest_kg) AS total_yield
+                    FROM harvests
+                    GROUP BY cycle_id
+                ) h ON c.id = h.cycle_id
+                WHERE b.group_type=%s AND c.plant_date BETWEEN %s AND %s
+                """,
+                (group_type, prev_start, prev_end),
+            )
+            prev = cur.fetchone()
+            prev_yield = prev["avg_yield"]
+            prev_days = prev["avg_days"]
+
+            yield_diff_prev = (
+                similar_yield - prev_yield
+                if similar_yield is not None and prev_yield is not None
+                else None
+            )
+            days_diff_prev = (
+                similar_days - prev_days
+                if similar_days is not None and prev_days is not None
+                else None
+            )
+
+            temp_end = harvest_start or expected_harvest
+            if plant_date and temp_end:
+                cur.execute(
+                    """
+                    SELECT AVG(temp_avg) AS avg_t,
+                           MAX(temp_max) AS max_t,
+                           MIN(temp_min) AS min_t,
+                           STDDEV(temp_avg) AS std_t,
+                           AVG(temp_max - temp_min) AS range_avg,
+                           STDDEV(temp_max - temp_min) AS range_std
+                    FROM weather_daily
+                    WHERE date BETWEEN %s AND %s
+                    """,
+                    (plant_date, temp_end),
+                )
+                temps = cur.fetchone()
+            else:
+                temps = {
+                    "avg_t": None,
+                    "max_t": None,
+                    "min_t": None,
+                    "std_t": None,
+                    "range_avg": None,
+                    "range_std": None,
+                }
+
+            cur.execute(
+                """
+                UPDATE cycles SET
+                    base_growth_days=%s,
+                    expected_harvest=%s,
+                    sales_adjust_days=%s,
+                    similar_bed_avg_yield=%s,
+                    similar_bed_avg_days=%s,
+                    prev_year_yield=%s,
+                    prev_year_days=%s,
+                    yield_diff_prev=%s,
+                    days_diff_prev=%s,
+                    temp_avg=%s,
+                    temp_max=%s,
+                    temp_min=%s,
+                    temp_std=%s,
+                    temp_range_avg=%s,
+                    temp_range_std=%s,
+                    season_flag=%s
+                WHERE id=%s
+                """,
+                (
+                    base_growth_days,
+                    expected_harvest,
+                    sales_adjust_days,
+                    similar_yield,
+                    similar_days,
+                    prev_yield,
+                    prev_days,
+                    yield_diff_prev,
+                    days_diff_prev,
+                    temps["avg_t"],
+                    temps["max_t"],
+                    temps["min_t"],
+                    temps["std_t"],
+                    temps["range_avg"],
+                    temps["range_std"],
+                    season_flag,
+                    cycle_id,
+                ),
+            )
+            conn.commit()
+
+            cur.execute("SELECT * FROM cycles WHERE id=%s", (cycle_id,))
+            features = cur.fetchone()
+            return features, None
+    finally:
+        conn.close()
+
+
+def predict(features, apply_partial=False, partial_yield=None, partial_ratio=None):
+    model_days = pickle.load(open("model_days_integrated.pkl", "rb"))
+    model_yield = pickle.load(open("model_yield_integrated.pkl", "rb"))
+    cols = [
+        "base_growth_days",
+        "similar_bed_avg_yield",
+        "similar_bed_avg_days",
+        "prev_year_yield",
+        "prev_year_days",
+        "yield_diff_prev",
+        "days_diff_prev",
+        "temp_avg",
+        "temp_max",
+        "temp_min",
+        "temp_std",
+        "temp_range_avg",
+        "temp_range_std",
+        "season_flag",
+    ]
+    df = pd.DataFrame([{c: features.get(c) for c in cols}])
+    pred_days = int(round(model_days.predict(df)[0]))
+    pred_yield = float(model_yield.predict(df)[0])
+    if apply_partial and partial_yield is not None and partial_ratio is not None:
+        pred_corrected = partial_yield + pred_yield * (1 - partial_ratio)
+    else:
+        pred_corrected = pred_yield
+    return pred_days, pred_yield, pred_corrected
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cycle_id", type=int, required=True)
+    parser.add_argument("--apply_partial", action="store_true")
+    parser.add_argument("--partial_yield", type=float)
+    parser.add_argument("--partial_ratio", type=float)
+    args = parser.parse_args()
+
+    features, err = compute_and_update_features(args.cycle_id)
+    if err:
+        print(json.dumps({"status": "error", "message": err}, ensure_ascii=False))
+        return
+
+    pred_days, pred_yield, pred_corr = predict(
+        features,
+        apply_partial=args.apply_partial,
+        partial_yield=args.partial_yield,
+        partial_ratio=args.partial_ratio,
+    )
+
+    result = {
+        "status": "success",
+        "cycle_id": args.cycle_id,
+        "expected_harvest_date": features["expected_harvest"].strftime("%Y-%m-%d")
+        if features["expected_harvest"]
+        else None,
+        "predicted_growth_days": pred_days,
+        "predicted_yield": round(pred_yield, 1),
+        "predicted_yield_corrected": round(pred_corr, 1),
+        "season_flag": features["season_flag"],
+        "sales_adjust_days": features["sales_adjust_days"],
+    }
+    print(json.dumps(result, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/alter_cycles_add_features.sql
+++ b/sql/alter_cycles_add_features.sql
@@ -1,0 +1,17 @@
+ALTER TABLE cycles
+ADD COLUMN base_growth_days INT NULL COMMENT '基準生育日数（季節別）',
+ADD COLUMN expected_harvest DATE NULL COMMENT '予定収穫日',
+ADD COLUMN sales_adjust_days INT NULL COMMENT '営業調整日数（実-予定）',
+ADD COLUMN similar_bed_avg_yield DECIMAL(8,2) NULL COMMENT '類似ベッド平均収量',
+ADD COLUMN similar_bed_avg_days DECIMAL(8,2) NULL COMMENT '類似ベッド平均日数',
+ADD COLUMN prev_year_yield DECIMAL(8,2) NULL COMMENT '前年同時期収量',
+ADD COLUMN prev_year_days DECIMAL(8,2) NULL COMMENT '前年同時期日数',
+ADD COLUMN yield_diff_prev DECIMAL(8,2) NULL COMMENT '収量差_前年',
+ADD COLUMN days_diff_prev DECIMAL(8,2) NULL COMMENT '日数差_前年',
+ADD COLUMN temp_avg DECIMAL(5,2) NULL COMMENT '平均気温',
+ADD COLUMN temp_max DECIMAL(5,2) NULL COMMENT '最高気温',
+ADD COLUMN temp_min DECIMAL(5,2) NULL COMMENT '最低気温',
+ADD COLUMN temp_std DECIMAL(5,2) NULL COMMENT '気温標準偏差',
+ADD COLUMN temp_range_avg DECIMAL(5,2) NULL COMMENT '平均日較差',
+ADD COLUMN temp_range_std DECIMAL(5,2) NULL COMMENT '日較差標準偏差',
+ADD COLUMN season_flag TINYINT NULL COMMENT '季節フラグ（1=夏, 2=冬, 3=中間期）';

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -11,6 +11,23 @@ CREATE TABLE cycles (
   plant_date DATE,
   harvest_start DATE,
   harvest_end DATE,
+  -- Extended feature columns
+  base_growth_days INT NULL COMMENT '基準生育日数（季節別）',
+  expected_harvest DATE NULL COMMENT '予定収穫日',
+  sales_adjust_days INT NULL COMMENT '営業調整日数（実-予定）',
+  similar_bed_avg_yield DECIMAL(8,2) NULL COMMENT '類似ベッド平均収量',
+  similar_bed_avg_days DECIMAL(8,2) NULL COMMENT '類似ベッド平均日数',
+  prev_year_yield DECIMAL(8,2) NULL COMMENT '前年同時期収量',
+  prev_year_days DECIMAL(8,2) NULL COMMENT '前年同時期日数',
+  yield_diff_prev DECIMAL(8,2) NULL COMMENT '収量差_前年',
+  days_diff_prev DECIMAL(8,2) NULL COMMENT '日数差_前年',
+  temp_avg DECIMAL(5,2) NULL COMMENT '平均気温',
+  temp_max DECIMAL(5,2) NULL COMMENT '最高気温',
+  temp_min DECIMAL(5,2) NULL COMMENT '最低気温',
+  temp_std DECIMAL(5,2) NULL COMMENT '気温標準偏差',
+  temp_range_avg DECIMAL(5,2) NULL COMMENT '平均日較差',
+  temp_range_std DECIMAL(5,2) NULL COMMENT '日較差標準偏差',
+  season_flag TINYINT NULL COMMENT '季節フラグ（1=夏, 2=冬, 3=中間期）',
   FOREIGN KEY (bed_id) REFERENCES beds(id)
 );
 


### PR DESCRIPTION
## Summary
- extend `cycles` table with growth, comparison and temperature feature columns
- add Python prediction script that computes features and invokes LightGBM models
- expose POST `/api/predict` endpoint to return predicted harvest metrics

## Testing
- `php -l api/predict.php`
- `python3 -m py_compile api/predict_model.py`


------
https://chatgpt.com/codex/tasks/task_e_689346cfe5688324b0edddf2b753c9c4