### PR TITLE
Add schema for forecast caching and alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment settings for prediction API
+XGB_API_URL=http://example.com/xgbapi/api/predict_both
+XGB_API_KEY=your_api_key_here

--- a/README.md
+++ b/README.md
@@ -7,21 +7,24 @@
 - MySQL 5.7+ または MariaDB 10+
 
 ## セットアップ手順
-1. `sql/schema.sql`、`sql/create_weather_daily.sql`、`sql/insert_weather_daily.sql`、`sql/sample_data.sql` をインポート  
+1. `sql/schema.sql`、`sql/create_weather_daily.sql`、`sql/insert_weather_daily.sql`、`sql/sample_data.sql`、`sql/forecast_extensions.sql` をインポート  
    - `insert_weather_daily.sql` はリポジトリ内の `ondo.xlsx` から気温データを登録します
-2. `db.php` の接続情報を設定
-3. `/data_entry/harvest.php` にブラウザでアクセス
+2. `.env.example` を `.env` にコピーし `XGB_API_URL` と `XGB_API_KEY` を設定
+3. `db.php` の接続情報を設定
+4. `/data_entry/harvest.php` にブラウザでアクセス
 
 ## ディレクトリ構成
 ```
 negi-harvest-system/
 ├── README.md
 ├── .gitignore
+├── .env.example
 ├── db.php
 ├── sql/
 │   ├── schema.sql
 │   ├── create_weather_daily.sql
 │   ├── insert_weather_daily.sql
+│   ├── forecast_extensions.sql
 │   └── sample_data.sql
 └── data_entry/
     ├── harvest.php

--- a/sql/forecast_extensions.sql
+++ b/sql/forecast_extensions.sql
@@ -1,0 +1,95 @@
+-- Additional tables and views for harvest forecasting
+
+CREATE TABLE IF NOT EXISTS calendar_shipments (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  week_start_date DATE NOT NULL UNIQUE,
+  committed_amount_kg DECIMAL(10,2) NOT NULL,
+  source ENUM('gcal','manual') NOT NULL,
+  gcal_event_id VARCHAR(255),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS collections (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  cycle_id INT NOT NULL,
+  pickup_date DATE NOT NULL,
+  amount_kg DECIMAL(10,2) NOT NULL,
+  client VARCHAR(255),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  INDEX (cycle_id, pickup_date),
+  FOREIGN KEY (cycle_id) REFERENCES cycles(id)
+);
+
+CREATE TABLE IF NOT EXISTS predictions (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  cycle_id INT NOT NULL,
+  model_id VARCHAR(64),
+  pred_days DECIMAL(8,3),
+  pred_total_kg DECIMAL(10,3),
+  postproc_days DECIMAL(8,3),
+  postproc_total_kg DECIMAL(10,3),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  INDEX (cycle_id, created_at),
+  FOREIGN KEY (cycle_id) REFERENCES cycles(id)
+);
+
+CREATE TABLE IF NOT EXISTS features_cache (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  cycle_id INT NOT NULL,
+  asof DATE NOT NULL,
+  features_json JSON NOT NULL,
+  hash CHAR(64) NOT NULL UNIQUE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  INDEX (cycle_id, asof),
+  FOREIGN KEY (cycle_id) REFERENCES cycles(id)
+);
+
+CREATE TABLE IF NOT EXISTS alerts (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  date DATE NOT NULL,
+  type ENUM('shortage','delay','loss_spike','data_missing') NOT NULL,
+  payload_json JSON,
+  status ENUM('open','closed') NOT NULL DEFAULT 'open',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  INDEX (type, date)
+);
+
+-- Forecast views
+CREATE OR REPLACE VIEW weekly_harvest_forecast_v AS
+SELECT
+  DATE_SUB(c.harvest_end, INTERVAL (DAYOFWEEK(c.harvest_end)-1) DAY) AS week_start_date,
+  SUM(COALESCE(p.postproc_total_kg, p.pred_total_kg)) AS forecast_total_kg
+FROM cycles c
+JOIN (
+  SELECT pr1.*
+  FROM predictions pr1
+  JOIN (
+    SELECT cycle_id, MAX(created_at) AS created_at
+    FROM predictions
+    GROUP BY cycle_id
+  ) pr2 ON pr1.cycle_id = pr2.cycle_id AND pr1.created_at = pr2.created_at
+) p ON c.id = p.cycle_id
+GROUP BY week_start_date;
+
+CREATE OR REPLACE VIEW weekly_gap_v AS
+SELECT
+  f.week_start_date,
+  f.forecast_total_kg,
+  s.committed_amount_kg,
+  f.forecast_total_kg - IFNULL(s.committed_amount_kg,0) AS diff_kg
+FROM weekly_harvest_forecast_v f
+LEFT JOIN calendar_shipments s ON f.week_start_date = s.week_start_date;
+
+-- Stored procedure example for sales adjust days
+DELIMITER $$
+CREATE PROCEDURE sp_update_sales_adjust_days(IN p_cycle_id INT)
+BEGIN
+  DECLARE exp DATE;
+  DECLARE actual DATE;
+  SELECT expected_harvest INTO exp FROM cycles WHERE id = p_cycle_id;
+  SELECT MIN(pickup_date) INTO actual FROM collections WHERE cycle_id = p_cycle_id;
+  IF exp IS NOT NULL AND actual IS NOT NULL THEN
+    UPDATE cycles SET sales_adjust_days = DATEDIFF(actual, exp) WHERE id = p_cycle_id;
+  END IF;
+END$$
+DELIMITER ;


### PR DESCRIPTION
## Summary
- define tables and views to cache predictions, track shipments, and surface alerts
- document environment variables and new SQL schema requirements
- include example `.env` template for API credentials

## Testing
- `php -l api/predict.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1a97f57308324a198544f6dffa959