### PR TITLE
Refactor planting data entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 ## セットアップ手順
 1. `sql/schema.sql`、`sql/create_weather_daily.sql`、`sql/insert_weather_daily.sql`、`sql/sample_data.sql`、`sql/forecast_extensions.sql` をインポート
+   - MySQL 5.5 では `JSON_OBJECT` などの JSON 関数が使えないため、JSON データは PHP 側で組み立ててください
    - `features_cache.features_json` や `alerts.payload_json` は TEXT 型なので、INSERT/UPDATE 前に `api/json_utils.php` の `encode_json` / `decode_json` で構造をチェックしてください
    - `insert_weather_daily.sql` はリポジトリ内の `ondo.xlsx` から気温データを登録します
 2. `.env.example` を `.env` にコピーし `XGB_API_URL` と `XGB_API_KEY` を設定
@@ -17,6 +18,7 @@
 ## 制約事項
 
 - データベースアクセスには MySQLi を使用し、PDO は使用しないでください。
+- 重要なエラーは `api/logging.php` の `log_error` を使用して `/home/love-media/forc_logs` に記録してください。
 
 ## ディレクトリ構成
 ```

--- a/api/logging.php
+++ b/api/logging.php
@@ -1,0 +1,10 @@
+<?php
+function log_error(string $message, string $filename = 'app.log'): void {
+    $dir = '/home/love-media/forc_logs';
+    if (!is_dir($dir)) {
+        mkdir($dir, 0777, true);
+    }
+    $timestamp = date('Y-m-d H:i:s');
+    error_log("[$timestamp] $message\n", 3, $dir . '/' . $filename);
+}
+?>


### PR DESCRIPTION
## Summary
- Remove obsolete `status` column when inserting cycles
- Add centralized `log_error` helper writing to `/home/love-media/forc_logs`
- Encode JSON payloads via `api/json_utils.php` for features cache and alerts
- Document logging and JSON rules in README

## Testing
- `php -l data_entry/planting.php`
- `php -l api/logging.php`


------
https://chatgpt.com/codex/tasks/task_e_68a2d7e43a248324b8e25f5dff4f5da5