### PR TITLE
Stop persisting expected harvest and add fallback feature builder

### DIFF
--- a/sql/patches/2025-08-18_sp_update_sales_adjust_days.sql
+++ b/sql/patches/2025-08-18_sp_update_sales_adjust_days.sql
@@ -1,0 +1,32 @@
+DROP PROCEDURE IF EXISTS sp_update_sales_adjust_days;
+DELIMITER //
+CREATE PROCEDURE sp_update_sales_adjust_days(IN p_cycle_id INT)
+BEGIN
+  DECLARE v_pickup DATE;
+  DECLARE v_plant  DATE;
+  DECLARE v_pred_days DECIMAL(8,3);
+  DECLARE v_expected DATE;
+
+  SELECT MIN(pickup_date) INTO v_pickup FROM collections WHERE cycle_id = p_cycle_id;
+  IF v_pickup IS NULL THEN LEAVE sp_update_sales_adjust_days; END IF;
+
+  SELECT plant_date INTO v_plant FROM cycles WHERE id = p_cycle_id;
+
+  SELECT pred_days INTO v_pred_days
+  FROM predictions
+  WHERE cycle_id = p_cycle_id AND created_at <= v_pickup
+  ORDER BY created_at DESC LIMIT 1;
+
+  IF v_pred_days IS NULL THEN
+    SELECT pred_days INTO v_pred_days
+    FROM predictions WHERE cycle_id = p_cycle_id
+    ORDER BY created_at DESC LIMIT 1;
+  END IF;
+  IF v_pred_days IS NULL THEN LEAVE sp_update_sales_adjust_days; END IF;
+
+  SET v_expected = DATE_ADD(v_plant, INTERVAL ROUND(v_pred_days) DAY);
+
+  -- 列がある環境のみ有効化
+  -- UPDATE cycles SET sales_adjust_days = DATEDIFF(v_pickup, v_expected) WHERE id = p_cycle_id;
+END //
+DELIMITER ;

--- a/sql/patches/2025-08-18_view_weekly_harvest_forecast.sql
+++ b/sql/patches/2025-08-18_view_weekly_harvest_forecast.sql
@@ -1,0 +1,23 @@
+CREATE OR REPLACE VIEW weekly_harvest_forecast_v AS
+WITH latest_pred AS (
+  SELECT p.*
+  FROM predictions p
+  JOIN (
+    SELECT cycle_id, MAX(created_at) AS last_ts
+    FROM predictions GROUP BY cycle_id
+  ) x ON x.cycle_id = p.cycle_id AND x.last_ts = p.created_at
+),
+final_date AS (
+  SELECT
+    c.id AS cycle_id,
+    COALESCE(c.harvest_end, DATE_ADD(c.plant_date, INTERVAL ROUND(lp.pred_days) DAY)) AS final_dt
+  FROM cycles c
+  LEFT JOIN latest_pred lp ON lp.cycle_id = c.id
+)
+SELECT
+  DATE_SUB(final_dt, INTERVAL (DAYOFWEEK(final_dt)-1) DAY) AS week_start_date,
+  SUM(COALESCE(lp.postproc_total_kg, lp.pred_total_kg)) AS forecast_total_kg,
+  COUNT(*) AS beds_count
+FROM final_date d
+LEFT JOIN latest_pred lp ON lp.cycle_id = d.cycle_id
+GROUP BY week_start_date;


### PR DESCRIPTION
## Summary
- drop cycles.expected_harvest updates and add stage-aware error logging in planting entry
- document temperature and neighbor fallbacks and runtime expected date in README
- add SQL patches for sales_adjust_days procedure and weekly forecast view

## Testing
- `php -l data_entry/planting.php`


------
https://chatgpt.com/codex/tasks/task_e_68a2fb94a7448324ac7c9c519dcd2248