### PR TITLE
Align temperature variation handling with rolling std data

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
    - メソッド: `POST`
    - エンドポイント: `/predict_both`
    - ヘッダー: `Content-Type: application/json` と `X-Api-Key`
-   - ボディ形式: 
+   - ボディ形式:
      ```json
      {
        "data": [
@@ -65,6 +65,7 @@
      }
      ```
      `"気温_平均"`、`"気温_最大"`、`"気温_最小"`、`"気温_std"`、`"気温振れ幅_平均"`、`"気温振れ幅_std"`、`"営業調整日数"` は必須です。
+     気温振れ幅系（`"気温振れ幅_*"`）は `weather_daily.variation`（`temp_avg` の rolling std）を期間平均・標準偏差した値を送信してください。`variation` が `NULL` の日は同じ rolling std ロジックで補完してから投入します。
 
 4. **レスポンス確認**  
    `ok: true` と `predictions` 配列に `days`（整数）と `yield`（実数）が含まれること、`request_id` が付与されることを確認します。入力に誤りがある場合は `ok: false` とエラーコードが返るため、メッセージに従って修正してください。

--- a/api/predict_model.py
+++ b/api/predict_model.py
@@ -134,8 +134,8 @@ def compute_and_update_features(cycle_id):
                            MAX(temp_max) AS max_t,
                            MIN(temp_min) AS min_t,
                            STDDEV(temp_avg) AS std_t,
-                           AVG(temp_max - temp_min) AS range_avg,
-                           STDDEV(temp_max - temp_min) AS range_std
+                           AVG(variation) AS range_avg,
+                           STDDEV(variation) AS range_std
                     FROM weather_daily
                     WHERE date BETWEEN %s AND %s
                     """,

--- a/lib/build_features.php
+++ b/lib/build_features.php
@@ -22,8 +22,8 @@ function aggregateTemperature($link, $plantDate, $asof) {
               MAX(temp_max) AS temp_max_max,
               MIN(temp_min) AS temp_min_min,
               STDDEV_POP(temp_avg) AS temp_avg_std,
-              AVG(COALESCE(variation, temp_max-temp_min)) AS swing_avg,
-              STDDEV_POP(COALESCE(variation, temp_max-temp_min)) AS swing_std
+              AVG(variation) AS swing_avg,
+              STDDEV_POP(variation) AS swing_std
             FROM weather_daily
             WHERE date BETWEEN ? AND ?";
     $stmt = mysqli_prepare($link, $sql);

--- a/xgbapi/README.md
+++ b/xgbapi/README.md
@@ -131,10 +131,9 @@ Note: JSON uses key `"yield"` (Pydantic uses `yield_ = Field(alias="yield")`).
   - `気温_最大 = MAX(temp_max)`
   - `気温_最小 = MIN(temp_min)`
   - `気温_std = STDDEV_POP(temp_avg)`
-  - `気温振れ幅_平均 = AVG(COALESCE(variation, temp_max - temp_min))`
-  - `気温振れ幅_std = STDDEV_POP(COALESCE(variation, temp_max - temp_min))`
-  - If `variation` is `NULL`, fall back to `(temp_max - temp_min)` upstream.
-    `variation` が `NULL` の日は上流処理で `(temp_max - temp_min)` にフォールバックしてください。
+  - `気温振れ幅_平均 = AVG(variation)` (`variation` は `temp_avg` の rolling std)
+  - `気温振れ幅_std = STDDEV_POP(variation)`
+  - `variation` が `NULL` の日は、同じ rolling std ロジックで欠損を補完してから投入してください。
 - Required: include `"営業調整日数" = COALESCE(cycles.sales_adjust_days, 0)` in features.
   必須: 特徴量に `"営業調整日数" = COALESCE(cycles.sales_adjust_days, 0)` を含めてください。
 - Input format: only `{"data":[{"features":{...}}]}` is accepted. Other styles (`records`, `X`, standalone `features`) are unsupported.


### PR DESCRIPTION
## Summary
- update the shared PHP/Python feature aggregation to read weather_daily.variation as the rolling standard deviation source for swing features
- refresh the root and xgbapi READMEs so the documented payload requirements describe the rolling std based variation column

## Testing
- php -l lib/build_features.php
- python -m compileall api/predict_model.py

------
https://chatgpt.com/codex/tasks/task_e_68ce52988cec8324b5886c6671bb9517